### PR TITLE
Feature/websocket readiness

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morpho-labs/ethers-fallback-provider",
-  "version": "1.0.0",
+  "version": "1.2.0-beta.2",
   "description": "Package providing a fallback provider based on ethers-providers, adding more resilience.",
   "main": "lib/index.js",
   "files": [
@@ -11,7 +11,9 @@
     "lint": "eslint ./src ./test --fix",
     "test:watch": "jest --watch",
     "test": "jest",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "set-registry:local": "yarn config set registry http://127.0.0.1:4873",
+    "set-registry:npm": "yarn config delete registry && npm config delete registry"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morpho-labs/ethers-fallback-provider",
-  "version": "1.2.0-beta.6",
+  "version": "1.1.0",
   "description": "Package providing a fallback provider based on ethers-providers, adding more resilience.",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morpho-labs/ethers-fallback-provider",
-  "version": "1.2.0-beta.3",
+  "version": "1.2.0-beta.4",
   "description": "Package providing a fallback provider based on ethers-providers, adding more resilience.",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morpho-labs/ethers-fallback-provider",
-  "version": "1.2.0-beta.2",
+  "version": "1.2.0-beta.3",
   "description": "Package providing a fallback provider based on ethers-providers, adding more resilience.",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -37,10 +37,12 @@
   "homepage": "https://github.com/morpho-labs/ethers-fallback-provider#readme",
   "dependencies": {
     "@ethersproject/logger": "^5.7.0",
-    "@ethersproject/providers": "^5.7.0"
+    "@ethersproject/providers": "^5.7.0",
+    "await-timeout": "^1.1.1"
   },
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.1.1",
+    "@types/await-timeout": "^0.3.3",
     "@types/jest": "^29.5.1",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morpho-labs/ethers-fallback-provider",
-  "version": "1.2.0-beta.4",
+  "version": "1.2.0-beta.5",
   "description": "Package providing a fallback provider based on ethers-providers, adding more resilience.",
   "main": "lib/index.js",
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@morpho-labs/ethers-fallback-provider",
-  "version": "1.2.0-beta.5",
+  "version": "1.2.0-beta.6",
   "description": "Package providing a fallback provider based on ethers-providers, adding more resilience.",
   "main": "lib/index.js",
   "files": [

--- a/src/utils/promises.ts
+++ b/src/utils/promises.ts
@@ -1,22 +1,8 @@
-export const promiseWithTimeout = async <T>(
-  promise: Promise<T>,
-  timeout: number
-): Promise<T> => {
-  return new Promise(async (resolve, reject) => {
-    const __timeoutExceeded__ = {};
+import Timeout from "await-timeout";
 
-    const result = await Promise.race([
-      promise.catch(reject),
-      wait(timeout, __timeoutExceeded__),
-    ]);
-
-    if (result === __timeoutExceeded__) reject("timeout exceeded");
-    resolve(result as T);
-  });
+export const promiseWithTimeout = async <T>(promise: Promise<T>, timeout: number): Promise<T> => {
+  return Timeout.wrap(promise, timeout, "timeout exceeded");
 };
 
-export const wait = <T>(
-  delay: number,
-  returnValue?: T
-): Promise<T | undefined> =>
+export const wait = <T>(delay: number, returnValue?: T): Promise<T | undefined> =>
   new Promise((resolve) => setTimeout(() => resolve(returnValue), delay));

--- a/src/utils/ws-util.ts
+++ b/src/utils/ws-util.ts
@@ -1,5 +1,3 @@
-import { WebSocketProvider } from "@ethersproject/providers";
-
 export const isWebSocketProvider = (provider: any) => {
-  return provider instanceof WebSocketProvider || !!provider._websocket // Could be a different instance of ethers.
-}
+  return !!provider.websocket;
+};

--- a/src/utils/ws-util.ts
+++ b/src/utils/ws-util.ts
@@ -1,0 +1,5 @@
+import { WebSocketProvider } from "@ethersproject/providers";
+
+export const isWebSocketProvider = (provider: any) => {
+  return provider instanceof WebSocketProvider || !!provider._websocket // Could be a different instance of ethers.
+}

--- a/test/FallbackProvider/FallbackProvider.test.ts
+++ b/test/FallbackProvider/FallbackProvider.test.ts
@@ -6,6 +6,7 @@ import {
 
 import FailingProvider from "./helpers/FailingProvider";
 import MockProvider from "./helpers/MockProvider";
+import MockWebsocketProvider from "./helpers/MockWebsocketProvider";
 
 describe("FallbackProvider", () => {
   beforeEach(() => {
@@ -120,6 +121,164 @@ describe("FallbackProvider", () => {
       expect(provider1.perform).toHaveBeenCalledTimes(2);
       expect(provider2.perform).toHaveBeenCalledTimes(1);
       expect(res).toEqual("2");
+    });
+
+    describe("Websocket providers", () => {
+      it("should fallback if the websocket is closing", async () => {
+        const provider1 = new MockWebsocketProvider("1");
+        const provider2 = new MockProvider("2");
+        const provider = new FallbackProvider([provider1, provider2]);
+
+        jest.spyOn(provider1, "perform");
+        jest.spyOn(provider2, "perform");
+
+        provider1.setWsReadyState(2);
+
+        const res = await provider.perform("send", {});
+
+        expect(provider1.perform).not.toHaveBeenCalled();
+        expect(provider2.perform).toHaveBeenCalledTimes(1);
+        expect(res).toEqual("2");
+      });
+
+      it("should fallback if the websocket is closed", async () => {
+        const provider1 = new MockWebsocketProvider("1");
+        const provider2 = new MockProvider("2");
+        const provider = new FallbackProvider([provider1, provider2]);
+
+        jest.spyOn(provider1, "perform");
+        jest.spyOn(provider2, "perform");
+
+        provider1.setWsReadyState(3);
+
+        const res = await provider.perform("send", {});
+
+        expect(provider1.perform).not.toHaveBeenCalled();
+        expect(provider2.perform).toHaveBeenCalledTimes(1);
+        expect(res).toEqual("2");
+      });
+
+      it("should fallback if the websocket is not ready", async () => {
+        const provider1 = new MockWebsocketProvider("1");
+        const provider2 = new MockProvider("2");
+        const provider = new FallbackProvider([provider1, provider2]);
+
+        jest.spyOn(provider1, "perform");
+        jest.spyOn(provider2, "perform");
+
+        provider1.setWsReadyState(0);
+
+        const res = await provider.perform("send", {});
+
+        expect(provider1.perform).not.toHaveBeenCalled();
+        expect(provider2.perform).toHaveBeenCalledTimes(1);
+        expect(res).toEqual("2");
+      });
+
+      it("should not fallback if the websocket is ready", async () => {
+        const provider1 = new MockWebsocketProvider("1");
+        const provider2 = new MockProvider("2");
+        const provider = new FallbackProvider([provider1, provider2]);
+
+        jest.spyOn(provider1, "perform");
+        jest.spyOn(provider2, "perform");
+
+        provider1.setWsReadyState(1);
+
+        const res = await provider.perform("send", {});
+
+        expect(provider1.perform).toHaveBeenCalledTimes(1);
+        expect(provider2.perform).not.toHaveBeenCalled();
+        expect(res).toEqual("1");
+      });
+
+      it("should fallback if the websocket is connecting but then proceed with the ws provider when the fallback fails", async () => {
+        const provider1 = new MockWebsocketProvider("1");
+        const provider2 = new FailingProvider("2");
+        const provider = new FallbackProvider([provider1, provider2]);
+
+        jest.spyOn(provider1, "perform");
+        jest.spyOn(provider2, "perform");
+
+        // When perform is called on provider2, make provider1 ready.
+        jest.spyOn(provider2, "perform").mockImplementationOnce(() => {
+          provider1.setWsReadyState(1);
+          return Promise.reject(new Error("Failed to perform"));
+        });
+
+        provider1.setWsReadyState(0);
+
+        const res = await provider.perform("send", {});
+
+        expect(provider1.perform).toHaveBeenCalledTimes(1);
+        expect(provider2.perform).toHaveBeenCalledTimes(1);
+        expect(res).toEqual("1");
+      });
+
+      it("should fallback if the websocket is closing, then fail when the fallback fails", async () => {
+        const provider1 = new MockWebsocketProvider("1");
+        const provider2 = new FailingProvider("2");
+        const provider = new FallbackProvider([provider1, provider2]);
+
+        provider1.setWsReadyState(2);
+
+        jest.spyOn(provider1, "perform");
+        jest.spyOn(provider2, "perform");
+
+        await expect(provider.perform("send", {})).rejects.toThrowError("Failing provider used: 2");
+
+        expect(provider1.perform).toHaveBeenCalledTimes(0); // Doesn't try performing since the ws is closing
+        expect(provider2.perform).toHaveBeenCalledTimes(1);
+      });
+
+      it("should fallback if the websocket is closed, then fail when the fallback fails", async () => {
+        const provider1 = new MockWebsocketProvider("1");
+        const provider2 = new FailingProvider("2");
+        const provider = new FallbackProvider([provider1, provider2]);
+
+        provider1.setWsReadyState(3);
+
+        jest.spyOn(provider1, "perform");
+        jest.spyOn(provider2, "perform");
+
+        await expect(provider.perform("send", {})).rejects.toThrowError("Failing provider used: 2");
+
+        expect(provider1.perform).not.toHaveBeenCalled(); // Doesn't try performing since the ws is closing
+        expect(provider2.perform).toHaveBeenCalledTimes(1);
+      });
+
+      it("should fallback if the websocket is forever connecting", async () => {
+        const provider1 = new MockWebsocketProvider("1");
+        const provider2 = new MockProvider("2");
+        const provider = new FallbackProvider([provider1, provider2]);
+
+        jest.spyOn(provider1, "perform");
+        jest.spyOn(provider2, "perform");
+
+        provider1.setWsReadyState(0);
+
+        const res = await provider.perform("send", {});
+
+        expect(provider1.perform).not.toHaveBeenCalled(); // Doesn't try performing since the ws never connects and we fallback
+        expect(provider2.perform).toHaveBeenCalledTimes(1);
+        expect(res).toEqual("2");
+      });
+
+      it("should fallback if the websocket is forever connecting, then proceed with the ws provider when the fallback fails, eventually failing", async () => {
+        const provider1 = new MockWebsocketProvider("1");
+        const provider2 = new FailingProvider("2");
+        const provider = new FallbackProvider([provider1, provider2]);
+
+        jest.spyOn(provider1, "perform");
+        jest.spyOn(provider2, "perform");
+
+        provider1.setWsReadyState(0);
+
+        await expect(provider.perform("send", {})).rejects.toThrowError("timeout exceeded");
+
+        expect(provider1.perform).toHaveBeenCalledTimes(1);
+        expect(provider2.perform).toHaveBeenCalledTimes(1);
+      });
     });
   });
 });

--- a/test/FallbackProvider/helpers/MockWebsocket.ts
+++ b/test/FallbackProvider/helpers/MockWebsocket.ts
@@ -1,0 +1,3 @@
+export default class MockWebsocket {
+  public readyState: number = 0;
+}

--- a/test/FallbackProvider/helpers/MockWebsocketProvider.ts
+++ b/test/FallbackProvider/helpers/MockWebsocketProvider.ts
@@ -1,0 +1,47 @@
+import { promiseWithTimeout } from "../../../src/utils/promises";
+
+import { default as MockProvider } from "./MockProvider";
+import { default as MockWebsocket } from "./MockWebsocket";
+
+export default class MockWebsocketProvider extends MockProvider {
+  protected _wsReady = false;
+  protected _websocket = new MockWebsocket();
+
+  constructor(_id: string, _networkId = 1) {
+    super(_id, _networkId);
+  }
+
+  setWsReadyState(state: number) {
+    this._websocket.readyState = state;
+  }
+
+  get websocket() {
+    return this._websocket;
+  }
+
+  async perform() {
+    const state = this._websocket.readyState;
+
+    if (state == 0) {
+      // Wait until the readyState is 1, timeout after 10 seconds
+      const startTime = Date.now();
+      const timeout = 10000;
+      const promise = new Promise((resolve, reject) => {
+        const interval = setInterval(() => {
+          if (this._websocket.readyState === 1) {
+            clearInterval(interval);
+            resolve(this._id);
+          } else if (Date.now() - startTime > timeout + 1000) {
+            clearInterval(interval);
+            reject("Websocket did not become ready");
+          }
+        }, 10);
+      }) as Promise<string>;
+      return await promiseWithTimeout(promise, timeout);
+    } else if (state === 1) {
+      return this._id;
+    } else {
+      throw new Error("Websocket is not ready");
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -893,6 +893,11 @@
     javascript-natural-sort "0.7.1"
     lodash "^4.17.21"
 
+"@types/await-timeout@^0.3.3":
+  version "0.3.3"
+  resolved "http://127.0.0.1:4873/@types/await-timeout/-/await-timeout-0.3.3.tgz#90ac71328061202dce11cda8a7ad4317d955340f"
+  integrity sha512-xed3pz+r3kzmQu03BEqRIR1YVW8jXluvlL/FgO0wTdySl14qDJKASEyDg7Ut+ufFROsoETxCiHYDjMhWPV3INg==
+
 "@types/babel__core@^7.1.14":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.0.tgz#61bc5a4cae505ce98e1e36c5445e4bee060d8891"
@@ -1184,6 +1189,11 @@ astral-regex@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+
+await-timeout@^1.1.1:
+  version "1.1.1"
+  resolved "http://127.0.0.1:4873/await-timeout/-/await-timeout-1.1.1.tgz#d42062ee6bc4eb271fe4d4f851eb658dae7e3906"
+  integrity sha512-gsDXAS6XVc4Jt+7S92MPX6Noq69bdeXUPEaXd8dk3+yVr629LTDLxNt4j1ycBbrU+AStK2PhKIyNIM+xzWMVOQ==
 
 babel-jest@^29.5.0:
   version "29.5.0"


### PR DESCRIPTION
### Description of change

Fixes #9 through the implementation of the following logic:
- If the ws is closing or closed, it does not try performing the call. Instead, it immediately falls back.
- If the ws is still connecting, it immediately falls back. If the fallbacks fail, it'll perform the call using the provided ws providers (that were in the connecting state) in reverse order.

Other changes:
- Introduces a new dependency: `await-timeout`
  - Reason: Test cases using the old `promiseWithTimeout` failed with odd behavior. They work nicely using `await-timeout`.

### Pull-Request Checklist

- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)